### PR TITLE
Update admin.py

### DIFF
--- a/multiupload/admin.py
+++ b/multiupload/admin.py
@@ -5,9 +5,9 @@ from django.contrib import admin
 from django.shortcuts import render, get_object_or_404
 from django.conf.urls import patterns,url
 from django.core.urlresolvers import reverse
-from django.utils import simplejson as json
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
+import json
 
 
 class MultiUploadAdmin(admin.ModelAdmin):


### PR DESCRIPTION
As of django 1.7, simplejson is removed, recommending use of the standard json library instead.
