### PR TITLE
Added support for Django 1.9

### DIFF
--- a/multiupload/admin.py
+++ b/multiupload/admin.py
@@ -71,7 +71,7 @@ class MultiUploadAdmin(admin.ModelAdmin):
             request, context, *args, **kwargs)
 
     def changelist_view(self, request, extra_context=None):
-        pop = request.REQUEST.get('pop')
+        pop = request.POST.get('pop')
         extra_context = extra_context or {}
         extra_context.update({
             'multiupload_list': self.multiupload_list,

--- a/multiupload/templates/multiupload/upload.html
+++ b/multiupload/templates/multiupload/upload.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify %}
-{% load url from future %}
 {% load raw %}
 
 {% block title %}Multiupload {{ block.super }}{% endblock %}


### PR DESCRIPTION
**WSGIRequest.REQUEST **property is removed in Django 1.9.
"_url tag from the future_" was also removed.
