### PR TITLE
change reverse import from core.urlresolvers to urls

### DIFF
--- a/multiupload/admin.py
+++ b/multiupload/admin.py
@@ -9,7 +9,7 @@ import json
 from django.contrib import admin
 from django.shortcuts import render, get_object_or_404
 from django.conf.urls import url
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 


### PR DESCRIPTION
django>2.1
python=3.7
It gives error of 'ImportError: No module named 'django.core.urlresolvers'
for these version of django and python3. This change solve the problem